### PR TITLE
A few small fixes

### DIFF
--- a/Beeblex-SDK/BBXIAPTransaction.m
+++ b/Beeblex-SDK/BBXIAPTransaction.m
@@ -107,7 +107,7 @@ const struct BBXIAPTransactionErrorCodes BBXIAPTransactionErrorCodes = {
                              
                              _transaction.transactionIdentifier, @"transactionId",
                              
-                             @(self.useSandbox), @"useSandbox",
+                             [NSNumber numberWithBool:self.useSandbox], @"useSandbox",
                              
                              Nil];
 

--- a/Beeblex-SDK/NSURLConnection+SendAsync.m
+++ b/Beeblex-SDK/NSURLConnection+SendAsync.m
@@ -40,12 +40,27 @@ typedef void (^URLConnectionCompletionHandler)(NSURLResponse *response, NSData *
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
     self.data = nil;
-    if (handler) { [queue addOperationWithBlock:^{ handler(response, nil, error); }]; }
+    if (handler) {
+        // Avoid retain cycles
+        URLConnectionCompletionHandler handlerCopy = self.handler;
+        NSURLResponse *responseCopy = self.response;
+        [queue addOperationWithBlock:^{
+            handlerCopy(responseCopy, nil, error);
+        }];
+    }
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection {
     // TODO: Are we passing the arguments to the block correctly? Should we copy them?
-    if (handler) { [queue addOperationWithBlock:^{ handler(response, data, nil); }]; }
+    if (handler) {
+        // Avoid retain cycles
+        URLConnectionCompletionHandler handlerCopy = self.handler;
+        NSURLResponse *responseCopy = self.response;
+        NSData *dataCopy = self.data;
+        [queue addOperationWithBlock:^{
+            handlerCopy(responseCopy, dataCopy, nil);
+        }];
+    }
 }
 
 @end

--- a/Beeblex-SDK/NSURLConnection+SendAsync.m
+++ b/Beeblex-SDK/NSURLConnection+SendAsync.m
@@ -31,11 +31,11 @@ typedef void (^URLConnectionCompletionHandler)(NSURLResponse *response, NSData *
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)theResponse {
     self.response = theResponse;
-    [data setLength:0]; // reset data
+    [self.data setLength:0]; // reset data
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)theData {
-    [data appendData:theData]; // append incoming data
+    [self.data appendData:theData]; // append incoming data
 }
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
@@ -44,7 +44,7 @@ typedef void (^URLConnectionCompletionHandler)(NSURLResponse *response, NSData *
         // Avoid retain cycles
         URLConnectionCompletionHandler handlerCopy = self.handler;
         NSURLResponse *responseCopy = self.response;
-        [queue addOperationWithBlock:^{
+        [self.queue addOperationWithBlock:^{
             handlerCopy(responseCopy, nil, error);
         }];
     }
@@ -57,7 +57,7 @@ typedef void (^URLConnectionCompletionHandler)(NSURLResponse *response, NSData *
         URLConnectionCompletionHandler handlerCopy = self.handler;
         NSURLResponse *responseCopy = self.response;
         NSData *dataCopy = self.data;
-        [queue addOperationWithBlock:^{
+        [self.queue addOperationWithBlock:^{
             handlerCopy(responseCopy, dataCopy, nil);
         }];
     }

--- a/Beeblex-SDK/_BBXCrypto.m
+++ b/Beeblex-SDK/_BBXCrypto.m
@@ -1296,11 +1296,10 @@
     buffer = (unsigned char *)calloc(length*4, sizeof(unsigned char));
     NSAssert((buffer != NULL), @"Cannot calloc memory for buffer.");
 
-    if (!RAND_bytes(buffer, length)){
-        free(buffer);
+    if (RAND_bytes(buffer, length)){
+        randData = [NSData dataWithBytes:buffer length:length];
     }
 
-    randData = [NSData dataWithBytes:buffer length:length];
     free(buffer);
 
     return randData;

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Beeblex-SDK
 
 The Beeblex SDK allows you to connect to Beeblex's services.
 
-For more inforamtion, visit [http://www.beeblex.com].
+For more information, visit [http://www.beeblex.com].


### PR DESCRIPTION
Here's a few more fixes to allow building the library in Xcode 4.3 and to avoid some potential retain cycles on IOS 4.

I am trying to test this on an iPhone 3G running iOS 4.2 and it seems to be encountering some problems still - namely it appears that the blowfish-encrypted data for the payload is probably not getting encoded properly (it is much smaller than what comes out on iOS 5, where it works). I suspect it is probably something in the crypto libraries, possibly in the armv6 code.

How exactly did you build the libssl and libcrypto libraries that are included in this project? They may be what is at fault here.
